### PR TITLE
Add Loop Talks group

### DIFF
--- a/run.rb
+++ b/run.rb
@@ -18,6 +18,7 @@ class App
    28497632, # Montevideo-Web-Developers
    17631212, # Rust-Uruguay
    5946782,  # py-mvd
+   31611165  # Loop-Talks
   ].join(",")
 
   def list_message


### PR DESCRIPTION
# Add Loop Talks group

Adds the group Loop Talks (https://www.meetup.com/Loop-Talks/) to the list of groups.