### PR TITLE
feat: supports Slack special characters in Meetup names

### DIFF
--- a/lib/meetup_bot/slack.ex
+++ b/lib/meetup_bot/slack.ex
@@ -52,7 +52,14 @@ defmodule MeetupBot.Slack do
   end
 
   defp to_bullet_item(meetup) do
-    name = meetup.name |> String.replace("|> ", "")
-    "• #{Calendar.strftime(meetup.datetime, "%-d %B - %H:%M")} - <#{meetup.event_url}|#{name}>"
+    "• #{Calendar.strftime(meetup.datetime, "%-d %B - %H:%M")} - <#{meetup.event_url}|#{escaped_text(meetup.name)}>"
+  end
+
+  defp escaped_text(text) do
+    # https://api.slack.com/reference/surfaces/formatting#escaping
+    text
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
   end
 end

--- a/test/slack_test.exs
+++ b/test/slack_test.exs
@@ -22,7 +22,7 @@ defmodule SlackTest do
         },
         {
           "type": "section",
-          "text": {"type": "mrkdwn", "text": "• 28 March - 22:00 - <http://example.com|Elixir Meetup>"}
+          "text": {"type": "mrkdwn", "text": "• 28 March - 22:00 - <http://example.com|Elixir |&gt; Meetup>"}
         }
       ]
     }


### PR DESCRIPTION
https://api.slack.com/reference/surfaces/formatting#escaping

https://app.slack.com/block-kit-builder/T0FJ9LF4K#%7B%22blocks%22:%5B%7B%22type%22:%22section%22,%22text%22:%7B%22type%22:%22mrkdwn%22,%22text%22:%22Hey%20%F0%9F%91%8B%20I'm%20%3Chttps://meetup.com%7CElixir%20%7C&gt;%20Montevideo%3E%22%7D%7D%5D%7D