### PR TITLE
feat:Add netmeetupuy to slack bot

### DIFF
--- a/lib/meetup_bot/meetup.ex
+++ b/lib/meetup_bot/meetup.ex
@@ -32,7 +32,8 @@ defmodule MeetupBot.Meetup do
     "aws-girls-ug-uy",
     "tryolabs-tech-talks",
     "fintech-dev-uruguay",
-    "flutter-montevideo"
+    "flutter-montevideo",
+    "netmeetupuy"
   ]
 
   alias MeetupBot.Event


### PR DESCRIPTION
This pull request updates the list of meetup groups in the `MeetupBot.Meetup` module by adding a new group to the list.

* [`lib/meetup_bot/meetup.ex`](diffhunk://#diff-33cf4f3886fe7d5dfcba1dd63d89c2f573370d4ef6da7a65219dabb8d9e8bfb5L35-R36): Added `"netmeetupuy"` to the list of meetup groups in the `MeetupBot.Meetup` module.